### PR TITLE
Update repository links to emblem.io WhatsApp receipts branch

### DIFF
--- a/PROJECT_COMPLETION_SUMMARY.md
+++ b/PROJECT_COMPLETION_SUMMARY.md
@@ -15,7 +15,7 @@
 ### 📚 **Research Analysis Portfolio** ✅ COMPLETE
 
 - ✅ **27/27 comprehensive paper analyses** completed across 7 ML domains
-- ✅ **GitHub Repository Live**: https://github.com/thisis-romar/cohere-scholars-2026-research-portfolio
+- ✅ **GitHub Repository Live**: https://github.com/thisis-romar/emblem.io-whatsapp-receipts
 - ✅ **Professional showcase** demonstrating engineering + research capabilities
 - ✅ **Strategic domain coverage**: Data Training, Inference, Architecture, Merging, Multimodal, Preference, Optimization
 

--- a/paper_link_generator.py
+++ b/paper_link_generator.py
@@ -39,7 +39,7 @@ def get_md_files_mapping():
 
 def create_github_link(paper_title, github_path):
     """Create a GitHub link for a paper analysis."""
-    base_url = "https://github.com/thisis-romar/cohere-scholars-2026-research-portfolio/blob/main/"
+    base_url = "https://github.com/thisis-romar/emblem.io-whatsapp-receipts/blob/main/"
     # URL encode the path properly
     encoded_path = quote(github_path, safe='/')
     return f"[{paper_title}]({base_url}{encoded_path})"


### PR DESCRIPTION
## Summary
- update documentation to reference the emblem.io WhatsApp receipts repository instead of the Cohere Scholars portfolio
- align the paper link generator script with the new repository base URL

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e547cce5e0832cafa81225b42fb5f2