### PR TITLE
Add starter directory for new GitHub repo

### DIFF
--- a/starter_repo/.gitignore
+++ b/starter_repo/.gitignore
@@ -1,0 +1,11 @@
+# Python
+__pycache__/
+*.py[cod]
+
+# Node.js
+node_modules/
+
+# General
+.DS_Store
+.env
+

--- a/starter_repo/README.md
+++ b/starter_repo/README.md
@@ -1,0 +1,18 @@
+# New GitHub Repository Starter
+
+This directory contains a minimal starter structure for a new GitHub repository.
+
+## Getting Started
+
+1. Update this README with project-specific information.
+2. Add your project files and organize them within this directory.
+3. Initialize the repository with `git init` (already initialized in parent repo if applicable).
+4. Create your first commit and push to a new GitHub repository.
+
+## Suggested Next Steps
+
+- Configure CI/CD workflows as needed.
+- Add a LICENSE file appropriate for your project.
+- Update `.gitignore` based on the languages and tools you plan to use.
+
+Happy coding!


### PR DESCRIPTION
## Summary
- add a starter_repo directory that provides a template README for kicking off a new GitHub project
- include a generic .gitignore to help ignore common artifacts for Python, Node.js, and general development

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68fa3367de1c832ca333cd9745347754