### PR TITLE
Initialize new project scaffold

### DIFF
--- a/new_project/README.md
+++ b/new_project/README.md
@@ -1,0 +1,25 @@
+# New Project
+
+This directory contains a starter Python project. It includes:
+
+- A `pyproject.toml` configured for a basic Poetry-managed package.
+- A simple `new_project` package inside `src/` with a demonstration function.
+- An entry point script in `main.py` to run from the command line.
+
+## Getting Started
+
+1. Install dependencies with Poetry:
+   ```bash
+   poetry install
+   ```
+2. Run the example script:
+   ```bash
+   poetry run python -m new_project.main
+   ```
+
+## Development Notes
+
+- The project targets Python 3.11.
+- Update the package metadata in `pyproject.toml` to match your needs.
+- Add your own modules under `src/new_project/` and tests under `tests/`.
+

--- a/new_project/pyproject.toml
+++ b/new_project/pyproject.toml
@@ -1,0 +1,17 @@
+[tool.poetry]
+name = "new-project"
+version = "0.1.0"
+description = "Starter Python project for the research portfolio repository"
+authors = ["Cohere Scholars <scholars@example.com>"]
+readme = "README.md"
+packages = [{ include = "new_project", from = "src" }]
+
+[tool.poetry.dependencies]
+python = "^3.11"
+
+[tool.poetry.group.dev.dependencies]
+pytest = "^7.4"
+
+[build-system]
+requires = ["poetry-core>=1.5.0"]
+build-backend = "poetry.core.masonry.api"

--- a/new_project/src/new_project/__init__.py
+++ b/new_project/src/new_project/__init__.py
@@ -1,0 +1,5 @@
+"""Starter package for the new project."""
+
+from .core import greet
+
+__all__ = ["greet"]

--- a/new_project/src/new_project/core.py
+++ b/new_project/src/new_project/core.py
@@ -1,0 +1,34 @@
+"""Core functionality for the new project."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+
+
+@dataclass(slots=True)
+class Greeting:
+    """Structured representation of a greeting message."""
+
+    message: str
+    timestamp: datetime
+
+    def format(self) -> str:
+        """Return the greeting message decorated with its timestamp."""
+        return f"[{self.timestamp.isoformat()}] {self.message}"
+
+
+def greet(name: str, *, at: datetime | None = None) -> Greeting:
+    """Create a :class:`Greeting` for ``name``.
+
+    Parameters
+    ----------
+    name:
+        The recipient of the greeting.
+    at:
+        Optional datetime to associate with the greeting. Defaults to ``datetime.utcnow()``.
+    """
+
+    timestamp = at or datetime.utcnow()
+    message = f"Welcome to the new project, {name}!"
+    return Greeting(message=message, timestamp=timestamp)

--- a/new_project/src/new_project/main.py
+++ b/new_project/src/new_project/main.py
@@ -1,0 +1,27 @@
+"""Command-line entry point for the new project."""
+
+from __future__ import annotations
+
+import argparse
+from datetime import datetime
+
+from .core import greet
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Demo CLI for the new project")
+    parser.add_argument("name", help="Name of the person to greet")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    greeting = greet(args.name, at=datetime.utcnow())
+    print(greeting.format())
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/new_project/tests/conftest.py
+++ b/new_project/tests/conftest.py
@@ -1,0 +1,7 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))

--- a/new_project/tests/test_core.py
+++ b/new_project/tests/test_core.py
@@ -1,0 +1,13 @@
+from datetime import datetime
+
+from new_project.core import Greeting, greet
+
+
+def test_greet_returns_greeting_with_expected_message():
+    timestamp = datetime(2024, 1, 1)
+    greeting = greet("Researcher", at=timestamp)
+
+    assert isinstance(greeting, Greeting)
+    assert greeting.message == "Welcome to the new project, Researcher!"
+    assert greeting.timestamp == timestamp
+    assert greeting.format() == "[2024-01-01T00:00:00] Welcome to the new project, Researcher!"


### PR DESCRIPTION
## Summary
- add a new_project directory with a Poetry-based Python package scaffold
- implement a Greeting dataclass and greeting helper with a CLI entry point
- configure pytest with an initial unit test ensuring the greeting output

## Testing
- pytest new_project/tests/test_core.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_68fa33517bec832c93f5c45e50d338ae)